### PR TITLE
feat: read ios/android paths from Capacitor config

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22,6 +22,7 @@
         "@robingenz/zli": "0.2.0",
         "@trapezedev/project": "7.1.3",
         "consola": "3.3.0",
+        "jiti": "2.6.1",
         "systeminformation": "5.25.11",
         "zod": "4.0.17"
       },
@@ -4007,13 +4008,10 @@
       "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="
     },
     "node_modules/jiti": {
-      "version": "2.4.2",
-      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.4.2.tgz",
-      "integrity": "sha512-rg9zJN+G4n2nfJl5MW3BMygZX56zKPNVEYYqq7adpmMh4Jn2QNEwhvQlFy6jPVdcod7txZtKHWnyZiA3a0zP7A==",
-      "dev": true,
+      "version": "2.6.1",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.6.1.tgz",
+      "integrity": "sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==",
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "bin": {
         "jiti": "lib/jiti-cli.mjs"
       }

--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "@robingenz/zli": "0.2.0",
     "@trapezedev/project": "7.1.3",
     "consola": "3.3.0",
+    "jiti": "2.6.1",
     "systeminformation": "5.25.11",
     "zod": "4.0.17"
   },

--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -1,3 +1,4 @@
+import { CapacitorPaths, loadCapacitorConfig } from '@/utils/capacitor-config.js';
 import { CliError } from '@/utils/error.js';
 import {
   Version,
@@ -26,9 +27,17 @@ export interface PlatformVersion {
 
 export class VersionService {
   private projectPath: string;
+  private capacitorPaths: CapacitorPaths | undefined;
 
   constructor(projectPath: string = process.cwd()) {
     this.projectPath = projectPath;
+  }
+
+  private async getCapacitorPaths(): Promise<CapacitorPaths> {
+    if (!this.capacitorPaths) {
+      this.capacitorPaths = await loadCapacitorConfig(this.projectPath);
+    }
+    return this.capacitorPaths;
   }
 
   async getAllVersions(): Promise<PlatformVersion[]> {
@@ -53,15 +62,16 @@ export class VersionService {
   }
 
   async getIosVersion(): Promise<PlatformVersion | null> {
-    const iosPath = join(this.projectPath, 'ios');
-    if (!existsSync(iosPath)) {
+    const { iosPath } = await this.getCapacitorPaths();
+    const fullIosPath = join(this.projectPath, iosPath);
+    if (!existsSync(fullIosPath)) {
       return null;
     }
 
     try {
       const project = new MobileProject(this.projectPath, {
         ios: {
-          path: 'ios/App',
+          path: `${iosPath}/App`,
         },
       });
       await project.load();
@@ -84,7 +94,7 @@ export class VersionService {
       return {
         platform: 'ios',
         version,
-        source: 'ios/App/App.xcodeproj/project.pbxproj',
+        source: `${iosPath}/App/App.xcodeproj/project.pbxproj`,
       };
     } catch (error) {
       return null;
@@ -92,15 +102,16 @@ export class VersionService {
   }
 
   async getAndroidVersion(): Promise<PlatformVersion | null> {
-    const androidPath = join(this.projectPath, 'android');
-    if (!existsSync(androidPath)) {
+    const { androidPath } = await this.getCapacitorPaths();
+    const fullAndroidPath = join(this.projectPath, androidPath);
+    if (!existsSync(fullAndroidPath)) {
       return null;
     }
 
     try {
       const project = new MobileProject(this.projectPath, {
         android: {
-          path: 'android',
+          path: androidPath,
         },
       });
       await project.load();
@@ -118,7 +129,7 @@ export class VersionService {
       return {
         platform: 'android',
         version,
-        source: 'android/app/build.gradle',
+        source: `${androidPath}/app/build.gradle`,
       };
     } catch (error) {
       return null;
@@ -151,19 +162,20 @@ export class VersionService {
   }
 
   async setVersion(version: Version): Promise<void> {
-    const iosPath = join(this.projectPath, 'ios');
-    const androidPath = join(this.projectPath, 'android');
+    const capacitorPaths = await this.getCapacitorPaths();
+    const fullIosPath = join(this.projectPath, capacitorPaths.iosPath);
+    const fullAndroidPath = join(this.projectPath, capacitorPaths.androidPath);
     const packageJsonPath = join(this.projectPath, 'package.json');
 
     const project = new MobileProject(this.projectPath, {
-      ios: existsSync(iosPath)
+      ios: existsSync(fullIosPath)
         ? {
-            path: 'ios/App',
+            path: `${capacitorPaths.iosPath}/App`,
           }
         : undefined,
-      android: existsSync(androidPath)
+      android: existsSync(fullAndroidPath)
         ? {
-            path: 'android',
+            path: capacitorPaths.androidPath,
           }
         : undefined,
     });

--- a/src/utils/capacitor-config.test.ts
+++ b/src/utils/capacitor-config.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import { mkdirSync, existsSync, writeFileSync, rmSync } from 'fs';
+import { join } from 'path';
+import { loadCapacitorConfig } from './capacitor-config.js';
+
+describe('capacitor-config', () => {
+  const testDir = '/tmp/capver-capacitor-config-test';
+
+  beforeEach(() => {
+    if (!existsSync(testDir)) {
+      mkdirSync(testDir, { recursive: true });
+    }
+  });
+
+  afterEach(() => {
+    rmSync(testDir, { recursive: true, force: true });
+  });
+
+  describe('loadCapacitorConfig', () => {
+    it('should return defaults when no config file exists', async () => {
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'ios',
+        androidPath: 'android',
+      });
+    });
+
+    it('should load paths from capacitor.config.json', async () => {
+      const config = {
+        appId: 'com.example.app',
+        ios: { path: 'custom-ios' },
+        android: { path: 'custom-android' },
+      };
+      writeFileSync(join(testDir, 'capacitor.config.json'), JSON.stringify(config));
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'custom-ios',
+        androidPath: 'custom-android',
+      });
+    });
+
+    it('should return defaults when capacitor.config.json has no paths', async () => {
+      const config = {
+        appId: 'com.example.app',
+      };
+      writeFileSync(join(testDir, 'capacitor.config.json'), JSON.stringify(config));
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'ios',
+        androidPath: 'android',
+      });
+    });
+
+    it('should return defaults for partial config (only ios)', async () => {
+      const config = {
+        appId: 'com.example.app',
+        ios: { path: 'custom-ios' },
+      };
+      writeFileSync(join(testDir, 'capacitor.config.json'), JSON.stringify(config));
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'custom-ios',
+        androidPath: 'android',
+      });
+    });
+
+    it('should return defaults for partial config (only android)', async () => {
+      const config = {
+        appId: 'com.example.app',
+        android: { path: 'custom-android' },
+      };
+      writeFileSync(join(testDir, 'capacitor.config.json'), JSON.stringify(config));
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'ios',
+        androidPath: 'custom-android',
+      });
+    });
+
+    it('should return defaults when JSON is malformed', async () => {
+      writeFileSync(join(testDir, 'capacitor.config.json'), '{ invalid }');
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'ios',
+        androidPath: 'android',
+      });
+    });
+
+    it('should prefer .ts over .js over .json', async () => {
+      const tsConfig = `
+        const config = {
+          appId: 'com.example.app',
+          ios: { path: 'from-ts' },
+          android: { path: 'from-ts' },
+        };
+        export default config;
+      `;
+      const jsonConfig = {
+        appId: 'com.example.app',
+        ios: { path: 'from-json' },
+        android: { path: 'from-json' },
+      };
+      writeFileSync(join(testDir, 'capacitor.config.ts'), tsConfig);
+      writeFileSync(join(testDir, 'capacitor.config.json'), JSON.stringify(jsonConfig));
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'from-ts',
+        androidPath: 'from-ts',
+      });
+    });
+
+    it('should load paths from capacitor.config.js', async () => {
+      const jsConfig = `
+        const config = {
+          appId: 'com.example.app',
+          ios: { path: 'from-js' },
+          android: { path: 'from-js' },
+        };
+        export default config;
+      `;
+      writeFileSync(join(testDir, 'capacitor.config.js'), jsConfig);
+
+      const result = await loadCapacitorConfig(testDir);
+      expect(result).toEqual({
+        iosPath: 'from-js',
+        androidPath: 'from-js',
+      });
+    });
+  });
+});

--- a/src/utils/capacitor-config.ts
+++ b/src/utils/capacitor-config.ts
@@ -1,0 +1,54 @@
+import { existsSync } from 'fs';
+import { readFile } from 'fs/promises';
+import { join } from 'path';
+
+export interface CapacitorPaths {
+  iosPath: string;
+  androidPath: string;
+}
+
+const DEFAULT_IOS_PATH = 'ios';
+const DEFAULT_ANDROID_PATH = 'android';
+
+const CONFIG_FILE_NAMES = ['capacitor.config.ts', 'capacitor.config.js', 'capacitor.config.json'];
+
+export const loadCapacitorConfig = async (projectPath: string = process.cwd()): Promise<CapacitorPaths> => {
+  for (const fileName of CONFIG_FILE_NAMES) {
+    const filePath = join(projectPath, fileName);
+    if (!existsSync(filePath)) {
+      continue;
+    }
+
+    try {
+      if (fileName.endsWith('.json')) {
+        const content = await readFile(filePath, 'utf-8');
+        const config = JSON.parse(content);
+        return extractPaths(config);
+      }
+
+      const { createJiti } = await import('jiti');
+      const jiti = createJiti(filePath);
+      const config = (await jiti.import(filePath)) as Record<string, unknown>;
+      return extractPaths(config);
+    } catch {
+      return defaults();
+    }
+  }
+
+  return defaults();
+};
+
+const extractPaths = (config: Record<string, unknown>): CapacitorPaths => {
+  const ios = config.ios as Record<string, unknown> | undefined;
+  const android = config.android as Record<string, unknown> | undefined;
+
+  return {
+    iosPath: typeof ios?.path === 'string' ? ios.path : DEFAULT_IOS_PATH,
+    androidPath: typeof android?.path === 'string' ? android.path : DEFAULT_ANDROID_PATH,
+  };
+};
+
+const defaults = (): CapacitorPaths => ({
+  iosPath: DEFAULT_IOS_PATH,
+  androidPath: DEFAULT_ANDROID_PATH,
+});


### PR DESCRIPTION
## Summary

- Add `loadCapacitorConfig()` utility that reads `ios.path` and `android.path` from `capacitor.config.{ts,js,json}` using `jiti` for TS/JS support
- Update `VersionService` to use configured paths instead of hardcoded `ios` and `android` directories
- Add tests for config loading (JSON, JS, TS, defaults, malformed input, priority order)

## Test plan

- [x] `npm run build` compiles without errors
- [x] `npm run test` — all 69 tests pass (8 new capacitor-config tests)
- [ ] Manual: create a project with custom `ios.path`/`android.path` in `capacitor.config.json` and run `capver get`

Close https://github.com/capawesome-team/capver/issues/4