### PR TITLE
fix: preserve Trapeze's $(MARKETING_VERSION) / $(CURRENT_PROJECT_VERSION) references in Info.plist

### DIFF
--- a/src/services/version.ts
+++ b/src/services/version.ts
@@ -188,17 +188,6 @@ export class VersionService {
     if (project.ios) {
       await project.ios.setVersion(null, null, versionString);
       await project.ios.setBuild(null, null, buildNumber.toString());
-
-      const infoPlistPath = await project.ios.getInfoPlist(null, null);
-      if (infoPlistPath) {
-        const infoPlist = await project.ios.getPlistFile(infoPlistPath);
-        if (infoPlist) {
-          await infoPlist.set({
-            CFBundleShortVersionString: versionString,
-            CFBundleVersion: buildNumber.toString(),
-          });
-        }
-      }
     }
 
     if (project.android) {


### PR DESCRIPTION
## Summary

`capver set <version>` was overwriting Trapeze's canonical Info.plist references (`$(MARKETING_VERSION)` / `$(CURRENT_PROJECT_VERSION)`) with literal values, defeating the single-source-of-truth pattern Xcode emits for new iOS projects.

Removed the explicit `infoPlist.set({ CFBundleShortVersionString, CFBundleVersion })` override in `VersionService.setVersion`. Trapeze's `setVersion` / `setBuild` already write the `$(...)` references to `Info.plist`, so `project.pbxproj` remains the single source of truth.

Closes #6